### PR TITLE
Fix signaling port mismatch

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -12,5 +12,7 @@ COPY jupitermeet_pro/server/ /app/
 # still use npm install (ci) with tolerance for peer deps
 RUN npm install --omit=dev --legacy-peer-deps
 
-EXPOSE 9000
+# Signalling server port
+EXPOSE 9007
+# Mediasoup uses a large UDP port range exposed via docker-compose
 CMD ["node", "app.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,10 @@ services:
     image: dev.kimidev.com/kimicom/jupitermeetpro-docker/node:1.8.6-prod
     restart: unless-stopped
     ports:
-      - "9000:9000"
+      # Match the signalling server's PORT from server/.env
+      - "9007:9007"
+      # Expose mediasoup UDP range for WebRTC
+      - "10000-59999:10000-59999/udp"
     volumes:
       - ./jupitermeet_pro/server/.env:/app/.env:ro
     command: ["npm", "run", "local"]   # HTTP-only mode

--- a/extras/docker-compose.dev.yml
+++ b/extras/docker-compose.dev.yml
@@ -35,6 +35,7 @@ services:
     command: npm run local      # HTTP mode, no TLS for dev
     ports:
       - "9000:9000"
+      - "10000-59999:10000-59999/udp"
     volumes:
       - ./jupitermeet_pro/server/.env.local:/app/.env:ro
     depends_on: [db]

--- a/extras/docker-compose.override.yml
+++ b/extras/docker-compose.override.yml
@@ -20,7 +20,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-node
-    ports: ["9000:9000"]
+    ports:
+      - "9007:9007"
+      - "10000-59999:10000-59999/udp"
 
 networks:
   default:

--- a/extras/docker-compose.yml
+++ b/extras/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     image: registry.kimihost.com/jupitermeet-node:1.8.6-fix
     restart: unless-stopped
     ports:
-      - "9000:9000"
+      - "9007:9007"
+      - "10000-59999:10000-59999/udp"
     # volumes:
     #  - ./jupitermeet_pro/server/.env.prod:/app/.env:ro
     extra_hosts:


### PR DESCRIPTION
## Summary
- update node container port mapping to match server PORT
- expose mediasoup UDP range for WebRTC

## Testing
- `npm install --legacy-peer-deps` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c89f4810c833091e9ef715044edc6